### PR TITLE
Fix KeyError for empty values in get_values()

### DIFF
--- a/pyjstat/pyjstat.py
+++ b/pyjstat/pyjstat.py
@@ -233,9 +233,10 @@ def get_values(js_dict, value='value'):
     max_val = max(values.keys(), key=int) + 1
     vals = []
     for i in range(0, max_val):
-        if values[i]:
+        try:
+          if values[i]:
             vals.append(values[i])
-        else:
+        except KeyError:
             vals.append(None)
     values = vals
     return values


### PR DESCRIPTION
Pesky ONS data! Was getting a KeyError using the following dataset

URL = http://web.ons.gov.uk/ons/api/data/dataset/CPI15.json?context=Economic&jsontype=json-stat&apikey={YOUR_API_KEY}&geog=2011STATH&diff=&totals=false
